### PR TITLE
Provide recipe to build latest version of sshpass

### DIFF
--- a/recipes-oss/packagegroups/packagegroup-protos-oss.bb
+++ b/recipes-oss/packagegroups/packagegroup-protos-oss.bb
@@ -1,0 +1,8 @@
+SUMMARY = "PROTOS open source software package group"
+
+inherit packagegroup
+
+RDEPENDS_${PN} = " \
+  sshpass \
+"
+

--- a/recipes-oss/sshpass/sshpass.inc
+++ b/recipes-oss/sshpass/sshpass.inc
@@ -1,0 +1,10 @@
+SUMMARY = "non-interactive ssh password auth"
+DESCRIPTION = "cli tool for non-interactive ssh password authentication"
+AUTHOR = "Shachar Shemesh <shachar@debian.org>"
+HOMEPAGE = "https://sourceforge.net/projects/sshpass/"
+BUGTRACKER = "https://sourceforge.net/p/sshpass/bugs/"
+SECTION = "console/network"
+LICENSE = "GPLv2"
+
+BBCLASSEXTEND = "native nativesdk"
+

--- a/recipes-oss/sshpass/sshpass_1.0.9.bb
+++ b/recipes-oss/sshpass/sshpass_1.0.9.bb
@@ -1,0 +1,22 @@
+require ${PN}.inc
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=94d55d512a9ba36caa9b7df079bae19f"
+SRC_URI = "${SOURCEFORGE_MIRROR}/sshpass/sshpass-${PV}.tar.gz"
+SRC_URI[sha256sum] = "71746e5e057ffe9b00b44ac40453bf47091930cba96bbea8dc48717dedc49fb7"
+
+inherit autotools
+
+do_install_append() {
+  install -d ${D}${docdir}/${PN}
+  install -m 0644 ${S}/COPYING ${D}/${docdir}/${PN}/LICENSE
+}
+
+# avoid empty -dev (no headers in source) and ship manpages and license file
+# in main package
+PACKAGES = "${PN} ${PN}-dbg {PN}-src"
+
+FILES_${PN} += "${docdir}"
+FILES_${PN} += "${mandir}"
+
+RDEPENDS_${PN} += "openssh"
+


### PR DESCRIPTION
- Add recipe to build sshpass version 1.0.9 and packagegroup for open
  source software (oss)
- Start using ${PN}_${PV}.bb and ${PN}.inc for 3rd party recipes and
  ${PN}_git.bb with corresponding ${PN}.inc for all git-based recipes
  to reflect common practices of openembedded and meta layers such as
  meta-clang, meta-qt5 and the likes.
  Furthermore, oelint-adv encourages this recipe name scheme too
- Closes #5 