### PR TITLE
Cppcheck website updated

### DIFF
--- a/recipes-oss/cppcheck/cppcheck.inc
+++ b/recipes-oss/cppcheck/cppcheck.inc
@@ -1,7 +1,7 @@
 SUMMARY = "Static analysis of C/C++ code"
 DESCRIPTION = "Cppcheck is a static analysis tool for C/C++ code. It provides unique code analysis to detect bugs and focuses on detecting undefined behaviour and dangerous coding constructs."
 AUTHOR = "Daniel Marjamäki <daniel.marjamaki@gmail.com>"
-HOMEPAGE = "https://github.com/danmar/cppcheck"
+HOMEPAGE = "http://cppcheck.sourceforge.net/"
 BUGTRACKER = "https://trac.cppcheck.net/"
 SECTION = "development"
 LICENSE = "GPL-3.0-or-later"


### PR DESCRIPTION
Point to the main Cppcheck website as GH is used for development only.