### PR TITLE
Add CVE_PRODUCT stubs

### DIFF
--- a/recipes-oss/cmocka/cmocka.inc
+++ b/recipes-oss/cmocka/cmocka.inc
@@ -5,3 +5,5 @@ HOMEPAGE = "https://cmocka.org/"
 BUGTRACKER = "https://gitlab.com/cmocka/cmocka/-/issues"
 SECTION = "development"
 LICENSE = "Apache-2"
+
+CVE_PRODUCT = ""

--- a/recipes-oss/cppcheck/cppcheck.inc
+++ b/recipes-oss/cppcheck/cppcheck.inc
@@ -5,3 +5,5 @@ HOMEPAGE = "http://cppcheck.sourceforge.net/"
 BUGTRACKER = "https://trac.cppcheck.net/"
 SECTION = "development"
 LICENSE = "GPL-3.0-or-later"
+
+CVE_PRODUCT = ""

--- a/recipes-oss/cpputest/cpputest.inc
+++ b/recipes-oss/cpputest/cpputest.inc
@@ -5,3 +5,5 @@ HOMEPAGE = "https://github.com/cpputest/cpputest"
 BUGTRACKER = "https://github.com/cpputest/cpputest/issues"
 SECTION = "development"
 LICENSE = "BSD-3-Clause"
+
+CVE_PRODUCT = ""

--- a/recipes-oss/sshpass/sshpass.inc
+++ b/recipes-oss/sshpass/sshpass.inc
@@ -6,3 +6,4 @@ BUGTRACKER = "https://sourceforge.net/p/sshpass/bugs/"
 SECTION = "console/network"
 LICENSE = "GPLv2"
 
+CVE_PRODUCT = ""


### PR DESCRIPTION
Adds an empty string stub for `CVE_PRODUCT` where no actual product is available.