### PR TITLE
Allow x86 and x86_64 library packages

### DIFF
--- a/conf/templates/local.conf.sample
+++ b/conf/templates/local.conf.sample
@@ -4,6 +4,9 @@ SDKMACHINE = "x86_64"
 
 DEFAULTTUNE ?= "i586"
 
+baselib = "${@d.getVar('BASE_LIB_tune-' + (d.getVar('DEFAULTTUNE') \
+    or 'INVALID')) or d.getVar('BASELIB')}"
+
 PATCHRESOLVE = "noop"
 
 EXTRA_IMAGE_FEATURES ?= "debug-tweaks"


### PR DESCRIPTION
- dynamically set baselib using BASE_LIB_tune-${DEFAULTTUNE}
  which already refers to lib64 in case of x86_64

  $ rpm -ql tmp/deploy/rpm/core2_64/libz1-1.2.11-r0.core2_64.rpm
  /lib64
  /lib64/libz.so.1
  /lib64/libz.so.1.2.11

- closes #39