### PR TITLE
meta-qt5 (5.14.2) still depends on python2

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,12 @@ This layer depends on:
 | ------------------- | ------------------------------------- |
 | poky                | [poky/dunfell](https://git.yoctoproject.org/cgit/cgit.cgi/poky/log/?h=dunfell)   |
 | meta-clang          | [meta-clang/dunfell](https://github.com/jhnc-oss/meta-clang/tree/dunfell)        |
-| meta-openembedded   | [meta-openembedded/dunfell](https://github.com/jhnc-oss/meta-openembedded/tree/dunfell)        |
 | meta-mingw          | [meta-mingw/dunfell](https://github.com/jhnc-oss/meta-mingw/tree/dunfell)        |
-| meta-selinux        | [meta-selinux/dunfell](https://github.com/jhnc-oss/meta-selinux/tree/dunfell)        |
+| meta-openembedded   | [meta-openembedded/dunfell](https://github.com/jhnc-oss/meta-openembedded/tree/dunfell)        |
+| meta-python2        | [meta-python2/dunfell](https://github.com/jhnc-oss/meta-python2/tree/dunfell)        |
 | meta-qt5            | [meta-qt5/dunfell](https://github.com/jhnc-oss/meta-qt5/tree/h5b/dunfell-5.12.4) |
+| meta-selinux        | [meta-selinux/dunfell](https://github.com/jhnc-oss/meta-selinux/tree/dunfell)        |
 
+## TODOs
+Drop legacy layer meta-python2 as soon as we can get rid of our dunfell-backport of Qt5.14.2 and switch
+to officially supported version as provided by meta-qt5.

--- a/conf/templates/bblayers.conf.sample
+++ b/conf/templates/bblayers.conf.sample
@@ -12,6 +12,7 @@ BBLAYERS ?= " \
    ${TOPDIR}/../meta-oe/meta-python \
    ${TOPDIR}/../meta-protos \
    ${TOPDIR}/../meta-protos/meta \
+   ${TOPDIR}/../meta-python2 \
    ${TOPDIR}/../meta-qt5 \
    ${TOPDIR}/../meta-selinux \
    ${TOPDIR}/../poky/meta \


### PR DESCRIPTION
Our dunfell-backport of Qt5 (5.14.2) heavily depends on python2. Therefore, enable meta-python2 legacy layer.