### PR TITLE
recipes: sanitize and cleanup recipes

### DIFF
--- a/recipes-oss/cmocka/cmocka_1.1.5.bb
+++ b/recipes-oss/cmocka/cmocka_1.1.5.bb
@@ -1,8 +1,8 @@
 require ${PN}.inc
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=3b83ef96387f14655fc854ddc3c6bd57"
-SRC_URI = "${GITLAB_MIRROR}/cmocka/cmocka/-/archive/cmocka-${PV}/cmocka-cmocka-${PV}.tar.gz"
-SRC_URI[sha256sum] = "51eba78277d51f0299617bedffc388b2b4ea478f5cc9876cc2544dae79638cb0"
+SRC_URI = "https://cmocka.org/files/1.1/cmocka-${PV}.tar.xz"
+SRC_URI[sha256sum] = "f0ccd8242d55e2fd74b16ba518359151f6f8383ff8aef4976e48393f77bba8b6"
 
 inherit cmake
 
@@ -15,8 +15,8 @@ EXTRA_OECMAKE = "\
 PACKAGES = "${PN}-dbg ${PN}"
 INSANE_SKIP_${PN} += "dev-so"
 
-FILES_${PN} += "${prefix}/include"
-FILES_${PN} += "${prefix}/lib"
+FILES_${PN} += "${includedir}"
+FILES_${PN} += "${libdir}"
 
 BBCLASSEXTEND = "native nativesdk"
 

--- a/recipes-oss/cppcheck/cppcheck.inc
+++ b/recipes-oss/cppcheck/cppcheck.inc
@@ -4,6 +4,6 @@ AUTHOR = "Daniel Marjamäki <daniel.marjamaki@gmail.com>"
 HOMEPAGE = "http://cppcheck.sourceforge.net/"
 BUGTRACKER = "https://trac.cppcheck.net/"
 SECTION = "development"
-LICENSE = "GPL-3.0-or-later"
+LICENSE = "GPL-3.0+"
 
 CVE_PRODUCT = ""

--- a/recipes-oss/cpputest/cpputest_4.0.bb
+++ b/recipes-oss/cpputest/cpputest_4.0.bb
@@ -16,8 +16,8 @@ EXTRA_OECMAKE = "\
 PACKAGES = "${PN}-dbg ${PN}"
 INSANE_SKIP_${PN} += "staticdev"
 
-FILES_${PN} += "${prefix}/include"
-FILES_${PN} += "${prefix}/lib"
+FILES_${PN} += "${includedir}"
+FILES_${PN} += "${libdir}"
 
 BBCLASSEXTEND = "native nativesdk"
 


### PR DESCRIPTION
- unbreak cmocka recipe
- switch to stable SRC_URI (gitlab and github are considered unstable by Q&A)
  were feasible
- make use of ${libdir} and ${includedir} for FILES_
- fix license