### PR TITLE
Add latest minizip (3.0.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,4 @@ This layer depends on:
 Drop legacy layer meta-python2 as soon as we can get rid of our dunfell-backport
 of [Qt5.12.4](https://github.com/jhnc-oss/meta-qt5/tree/backport/5.12.4-dunfell-23.0.11)
 and switch to officially supported version as provided by meta-qt5.
+

--- a/recipes-oss/cppcheck/cppcheck_2.6.bb
+++ b/recipes-oss/cppcheck/cppcheck_2.6.bb
@@ -2,8 +2,11 @@ require ${PN}.inc
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
 DEPENDS += "libpcre"
-SRC_URI = "${GITHUB_MIRROR}/danmar/cppcheck/archive/refs/tags/${PV}.tar.gz"
-SRC_URI[sha256sum] = "99f0c5cf58a0072876c4deb114f3f5f798c933b8e459cddb00a061c8bb4dd765"
+
+SRC_URI = "git://github.com/danmar/cppcheck.git;protocol=https;nobranch=1"
+SRCREV = "d873b8e77189cf6b974fc9d403df8e8500eded7b"
+
+S = "${WORKDIR}/git"
 
 inherit cmake
 

--- a/recipes-oss/minizip-ng/minizip.inc
+++ b/recipes-oss/minizip-ng/minizip.inc
@@ -1,0 +1,10 @@
+SUMMARY = "Fork of the popular zip manipulation library found in the zlib distribution"
+DESCRIPTION = "minizip-ng is a zip manipulation library written in C that is supported on Windows, macOS, and Linux."
+AUTHOR = "Nathan Moinvaziri <nathan@nathanm.com>"
+HOMEPAGE = "https://www.github.com/zlib-ng/minizip-ng"
+BUGTRACKER = "https://www.github.com/zlib-ng/minizip-ng/issues"
+SECTION = "tools"
+LICENSE = "Zlib"
+
+CVE_PRODUCT = ""
+

--- a/recipes-oss/minizip-ng/minizip_3.0.3.bb
+++ b/recipes-oss/minizip-ng/minizip_3.0.3.bb
@@ -1,0 +1,28 @@
+require ${PN}.inc
+
+LIC_FILES_CHKSUM = "file://LICENSE;md5=36964f044224efeedd694983c34e716f"
+
+DEPENDS += "\
+    bzip2 \
+    libbsd \
+    openssl \
+    xz \
+    zlib \
+    zstd \
+"
+
+SRC_URI = "git://github.com/zlib-ng/minizip-ng.git;branch=master;protocol=https"
+SRCREV = "99d39015e29703af2612277180ea586805f655ea"
+
+S = "${WORKDIR}/git"
+
+inherit cmake pkgconfig
+
+# Specify any options you want to pass to cmake using EXTRA_OECMAKE:
+EXTRA_OECMAKE = "\
+    -DBUILD_SHARED_LIBS=ON \
+    -DCMAKE_INSTALL_INCLUDEDIR=${includedir}/${PN}-ng \
+"
+
+BBCLASSEXTEND = "native nativesdk"
+

--- a/recipes-oss/packagegroups/packagegroup-protos-oss.bb
+++ b/recipes-oss/packagegroups/packagegroup-protos-oss.bb
@@ -7,6 +7,7 @@ RDEPENDS_${PN} = "\
     cmocka \
     cppcheck \
     cpputest \
+    minizip-ng \
     sshpass \
 "
 


### PR DESCRIPTION
Add latest minizip (3.0.3) and switch cppcheck to
SRCREV in the veins of openembedded and the likes
when it comes to Github source archives.