### PR TITLE
Overlay to unbreak recipes needing python2 legacy

### DIFF
--- a/conf/templates/bblayers.conf.sample
+++ b/conf/templates/bblayers.conf.sample
@@ -12,6 +12,7 @@ BBLAYERS ?= " \
    ${TOPDIR}/../meta-oe/meta-python \
    ${TOPDIR}/../meta-protos \
    ${TOPDIR}/../meta-protos/meta \
+   ${TOPDIR}/../meta-protos/meta-oe \
    ${TOPDIR}/../meta-python2 \
    ${TOPDIR}/../meta-qt5 \
    ${TOPDIR}/../meta-selinux \

--- a/meta-oe/conf/layer.conf/layer.conf
+++ b/meta-oe/conf/layer.conf/layer.conf
@@ -1,0 +1,15 @@
+# We have a conf and classes directory, add to BBPATH
+BBPATH .= ":${LAYERDIR}"
+
+# We have recipes-* directories, add to BBFILES
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
+            ${LAYERDIR}/recipes-*/*/*.bbappend"
+
+BBFILE_COLLECTIONS += "meta"
+BBFILE_PATTERN_meta = "^${LAYERDIR}/"
+
+# enforce precedence over any other layer
+BBFILE_PRIORITY_meta = "10"
+
+LAYERDEPENDS_meta = "core"
+LAYERSERIES_COMPAT_meta = "dunfell"

--- a/meta-oe/recipes-devtools/sip/sip_4.19.16.bb
+++ b/meta-oe/recipes-devtools/sip/sip_4.19.16.bb
@@ -1,0 +1,46 @@
+SUMMARY = "SIP is a C++/Python Wrapper Generator"
+HOMEPAGE = "http://www.riverbankcomputing.co.uk/sip"
+SECTION = "devel"
+LICENSE = "GPLv2+"
+LIC_FILES_CHKSUM = "file://LICENSE-GPL2;md5=e91355d8a6f8bd8f7c699d62863c7303"
+
+SRC_URI = "https://src.fedoraproject.org/lookaside/pkgs/sip/sip-${PV}.tar.gz"
+SRC_URI[sha256sum] = "184c790d58e9527fc6bdac2bbf8638f3d1b41dea922cad8eb83172b4ba70c620"
+
+S = "${WORKDIR}/sip-${PV}"
+
+BBCLASSEXTEND = "native"
+
+DEPENDS = "python"
+
+inherit python-dir pythonnative
+
+PACKAGES += "python-sip"
+
+do_configure_prepend_class-target() {
+    echo "py_platform = linux" > sip.cfg
+    echo "py_inc_dir = %(sysroot)/${includedir}/python%(py_major).%(py_minor)${PYTHON_ABI}" >> sip.cfg
+    echo "sip_bin_dir = ${D}/${bindir}" >> sip.cfg
+    echo "sip_inc_dir = ${D}/${includedir}" >> sip.cfg
+    echo "sip_module_dir = ${D}/${libdir}/python%(py_major).%(py_minor)/site-packages" >> sip.cfg
+    echo "sip_sip_dir = ${D}/${datadir}/sip" >> sip.cfg
+    ${PYTHON} configure.py --configuration sip.cfg --sip-module PyQt5.sip --sysroot ${STAGING_DIR_HOST} CC="${CC}" CXX="${CXX}" LINK="${CXX}" STRIP="" LINK_SHLIB="${CXX}" CFLAGS="${CFLAGS}" CXXFLAGS="${CXXFLAGS}" LFLAGS="${LDFLAGS}"
+}
+
+do_configure_prepend_class-native() {
+    echo "py_platform = linux" > sip.cfg
+    echo "py_inc_dir = ${includedir}/python%(py_major).%(py_minor)${PYTHON_ABI}" >> sip.cfg
+    echo "sip_bin_dir = ${D}/${bindir}" >> sip.cfg
+    echo "sip_inc_dir = ${D}/${includedir}" >> sip.cfg
+    echo "sip_module_dir = ${D}/${libdir}/python%(py_major).%(py_minor)/site-packages" >> sip.cfg
+    echo "sip_sip_dir = ${D}/${datadir}/sip" >> sip.cfg
+    ${PYTHON} configure.py --configuration sip.cfg --sip-module PyQt5.sip --sysroot=${STAGING_DIR_NATIVE}
+}
+
+do_install() {
+    oe_runmake install
+}
+
+FILES_python-sip = "${libdir}/${PYTHON_DIR}/site-packages/"
+FILES_${PN}-dbg += "${libdir}/${PYTHON_DIR}/site-packages/.debug"
+


### PR DESCRIPTION
Add SIP wrapper for Python2 to unbreak recipes in current
backport of meta-qt5 that depend on it, e.g python-pyqt5