### PR TITLE
recipe: update to latest versions

### DIFF
--- a/meta-oe/recipes-support/fmt/fmt_8.0.1.1.bb
+++ b/meta-oe/recipes-support/fmt/fmt_8.0.1.1.bb
@@ -7,7 +7,7 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE.rst;md5=af88d758f75f3c5c48a967501f24384b"
 
 SRC_URI = "git://github.com/jhnc-oss/fmt;branch=8.0.1-jh"
-SRCREV = "a23c8e0a61cceab99c33264628527fb8447fbb84"
+SRCREV = "a9a4a93113bb98781432f25b2a97959e2753ea20"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-devtools/extra-cmake-modules/extra-cmake-modules_5.89.0.bb
+++ b/recipes-devtools/extra-cmake-modules/extra-cmake-modules_5.89.0.bb
@@ -3,7 +3,7 @@ require ${PN}.inc
 LIC_FILES_CHKSUM = "file://COPYING-CMAKE-SCRIPTS;md5=54c7042be62e169199200bc6477f04d1"
 
 SRC_URI = "https://invent.kde.org/frameworks/${BPN}/-/archive/v${PV}/${BPN}-v${PV}.tar.gz"
-SRC_URI[sha256sum] = "779e90d0151ec0759450176e7a5870a37b8f849651f9e6371d4d86bc6ce912bb"
+SRC_URI[sha256sum] = "1236135d5f82c4d1e432d38fa2adb7f4843f0735c734392311a5b296358e726a"
 
 S = "${WORKDIR}/${BPN}-v${PV}"
 


### PR DESCRIPTION
- update extra-cmake-modules to latest stable version
- update fmt to https://github.com/jhnc-oss/fmt/commit/a9a4a93113bb98781432f25b2a97959e2753ea20
  (Note: header changes on 14.12.2021 do no longer compile)
- closes #59