### PR TITLE
Update cppcheck 2.7

### DIFF
--- a/recipes-oss/cppcheck/cppcheck_2.7.bb
+++ b/recipes-oss/cppcheck/cppcheck_2.7.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
 DEPENDS += "libpcre"
 
 SRC_URI = "git://github.com/danmar/cppcheck.git;protocol=https;nobranch=1"
-SRCREV = "d873b8e77189cf6b974fc9d403df8e8500eded7b"
+SRCREV = "6ba6567ad897d56741159f8af90fc354ae050e61"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Update Cppcheck to latest v2.7 release.

closes #67 