### PR TITLE
Add backport notes

### DIFF
--- a/recipes-oss/cmocka/backport.md
+++ b/recipes-oss/cmocka/backport.md
@@ -1,0 +1,3 @@
+# Backport
+
+Available with *meta-oe gatesgarth (Yocto Project 3.2)*.

--- a/recipes-oss/cpputest/backport.md
+++ b/recipes-oss/cpputest/backport.md
@@ -1,0 +1,3 @@
+# Backport
+
+Available with *meta-oe honister (Yocto Project 3.4)*.


### PR DESCRIPTION
Adds marker files for backported recipes, incl. a note when to drop them.

Since the upcoming LTS includes all of them, I've added a related task to [planing](https://github.com/orgs/jhnc-oss/projects/2#card-77362443).