### PR TITLE
Update Audit to v3.0.8

### DIFF
--- a/recipes-oss/audit/audit_3.0.8.bb
+++ b/recipes-oss/audit/audit_3.0.8.bb
@@ -5,10 +5,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=94d55d512a9ba36caa9b7df079bae19f"
 SRC_URI = "\
     https://people.redhat.com/sgrubb/audit/audit-${PV}.tar.gz \
     file://Fixed-swig-host-contamination-issue.patch \
-    file://0001-flush-uid-gid-caches-when-user-group-added-deleted-m.patch \
 "
 
-SRC_URI[sha256sum] = "8c5ae825b9d2837742b626fa93b86cb4a84d15530bf05b6cb42be3f304db8cf6"
+SRC_URI[sha256sum] = "b5f4d9b9ad69381ee18f33d3d918326aa52861509c901143f8a8c4ed5caa8913"
 
 inherit autotools
 
@@ -30,4 +29,3 @@ FILES_${PN} += "${docdir}"
 FILES_${PN} += "${mandir}"
 
 BBCLASSEXTEND = "native nativesdk"
-


### PR DESCRIPTION
Updates Audit to latest v3.0.8. The removed patch was integrated by an earlier version (3.0.5) already.