### PR TITLE
image: add x11-base to protos-core-image-dev

### DIFF
--- a/recipes-core/images/protos-core-image-dev.bb
+++ b/recipes-core/images/protos-core-image-dev.bb
@@ -2,5 +2,6 @@ DESCRIPTION = "PROTOS core image suitable for development work."
 
 IMAGE_FEATURES += "dev-pkgs"
 IMAGE_FEATURES += "tools-sdk"
+IMAGE_FEATURES += "x11-base"
 
 inherit core-image


### PR DESCRIPTION
- add x11-base to protos-core-image-dev to support building
  basic X applications such as xorg-xeyes
- closes #83