### PR TITLE
recipe: libdir needs to be executable

### DIFF
--- a/recipes-oss/debugpy/debugpy_1.6.0.bb
+++ b/recipes-oss/debugpy/debugpy_1.6.0.bb
@@ -28,6 +28,10 @@ do_compile_append() {
     mv ${@get_so_target(d)}.so ../${@get_so_target(d)}.so
 }
 
+do_install_append() {
+    chmod -R 0755 ${D}${libdir}
+}
+
 inherit pypi setuptools3
 
 BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
debugpy's install routine is flawed but we need to install libdir executable