### PR TITLE
Avoid INSANE_SKIP and package as upstream does

### DIFF
--- a/recipes-oss/cmocka/cmocka_1.1.5.bb
+++ b/recipes-oss/cmocka/cmocka_1.1.5.bb
@@ -11,12 +11,5 @@ EXTRA_OECMAKE = "\
     -DWITH_EXAMPLES=OFF \
 "
 
-# Build as single package
-PACKAGES = "${PN}-dbg ${PN}"
-INSANE_SKIP_${PN} += "dev-so"
-
-FILES_${PN} += "${includedir}"
-FILES_${PN} += "${libdir}"
-
 BBCLASSEXTEND = "native nativesdk"
 

--- a/recipes-oss/cpputest/cpputest.inc
+++ b/recipes-oss/cpputest/cpputest.inc
@@ -3,7 +3,7 @@ DESCRIPTION = "CppUTest is a C /C++ based unit xUnit test framework for unit tes
 AUTHOR = "CppUTest"
 HOMEPAGE = "https://github.com/cpputest/cpputest"
 BUGTRACKER = "https://github.com/cpputest/cpputest/issues"
-SECTION = "development"
+SECTION = "devel"
 LICENSE = "BSD-3-Clause"
 
 CVE_PRODUCT = ""

--- a/recipes-oss/cpputest/cpputest_4.0.bb
+++ b/recipes-oss/cpputest/cpputest_4.0.bb
@@ -12,12 +12,6 @@ EXTRA_OECMAKE = "\
     -DLONGLONG=ON \
 "
 
-# Build as single package
-PACKAGES = "${PN}-dbg ${PN}"
-INSANE_SKIP_${PN} += "staticdev"
-
-FILES_${PN} += "${includedir}"
-FILES_${PN} += "${libdir}"
 FILES_${PN}-dev += "${libdir}/CppUTest/cmake/*"
 
 BBCLASSEXTEND = "native nativesdk"

--- a/recipes-oss/cpputest/cpputest_4.0.bb
+++ b/recipes-oss/cpputest/cpputest_4.0.bb
@@ -18,5 +18,6 @@ INSANE_SKIP_${PN} += "staticdev"
 
 FILES_${PN} += "${includedir}"
 FILES_${PN} += "${libdir}"
+FILES_${PN}-dev += "${libdir}/CppUTest/cmake/*"
 
 BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
Removes usages of `INSANE_SKIP` and creates packages as upstream *meta-oe* does.