### PR TITLE
Backport nlohmann json 3.11.2

### DIFF
--- a/recipes-oss/nlohmann-json/backport.md
+++ b/recipes-oss/nlohmann-json/backport.md
@@ -1,0 +1,3 @@
+# Backport
+
+Available with *meta-oe > kirkstone (Yocto Project > 4.0)*.

--- a/recipes-oss/nlohmann-json/nlohmann-json_3.11.2.bb
+++ b/recipes-oss/nlohmann-json/nlohmann-json_3.11.2.bb
@@ -1,0 +1,32 @@
+# Upstream version: 502262820a4746ffd930dee350dcba176410edbb
+
+SUMMARY = "JSON for modern C++"
+HOMEPAGE = "https://nlohmann.github.io/json/"
+SECTION = "libs"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE.MIT;md5=f969127d7b7ed0a8a63c2bbeae002588"
+
+CVE_PRODUCT = "json-for-modern-cpp"
+
+SRC_URI = "git://github.com/nlohmann/json.git;nobranch=1;protocol=https \
+           "
+
+SRCREV = "bc889afb4c5bf1c0d8ee29ef35eaaf4c8bef8a5d"
+
+S = "${WORKDIR}/git"
+
+inherit cmake
+
+EXTRA_OECMAKE += "-DJSON_BuildTests=OFF"
+
+# nlohmann-json is a header only C++ library, so the main package will be empty.
+
+RDEPENDS:${PN}-dev = ""
+
+BBCLASSEXTEND = "native nativesdk"
+
+# other packages commonly reference the file directly as "json.hpp"
+# create symlink to allow this usage
+do_install:append() {
+    ln -s nlohmann/json.hpp ${D}${includedir}/json.hpp
+}


### PR DESCRIPTION
Backport of nlohmann json 3.11.2. The recipe is on upstream master only, there's no yocto release yet (#92)