### PR TITLE
ALLOW_EMPTY_${PN} to unbreak populate_sdk

### DIFF
--- a/recipes-oss/cpputest/cpputest_4.0.bb
+++ b/recipes-oss/cpputest/cpputest_4.0.bb
@@ -14,4 +14,6 @@ EXTRA_OECMAKE = "\
 
 FILES_${PN}-dev += "${libdir}/CppUTest/cmake/*"
 
+ALLOW_EMPTY_${PN} = "1"
+
 BBCLASSEXTEND = "native nativesdk"

--- a/recipes-oss/nlohmann-json/nlohmann-json_3.11.2.bb
+++ b/recipes-oss/nlohmann-json/nlohmann-json_3.11.2.bb
@@ -23,6 +23,8 @@ EXTRA_OECMAKE += "-DJSON_BuildTests=OFF"
 
 RDEPENDS:${PN}-dev = ""
 
+ALLOW_EMPTY_${PN} = "1"
+
 BBCLASSEXTEND = "native nativesdk"
 
 # other packages commonly reference the file directly as "json.hpp"


### PR DESCRIPTION
Set ALLOW_EMPTY_${PN} = "1" for cpputest and nlohmann-json as those recipes have empty ${PN} packages which leads breaks populate_sdk as dnf is no longer able to find the package.