### PR TITLE
Sync upstream backports

### DIFF
--- a/recipes-oss/cpputest/backport.md
+++ b/recipes-oss/cpputest/backport.md
@@ -1,3 +1,5 @@
 # Backport
 
-Available with *meta-oe honister (Yocto Project 3.4)*.
+Available with *meta-oe > honister (Yocto Project > 3.4)*.
+
+Upstream revision: `8c0402f7c47188cef1d6afc68c0427124940ea57`

--- a/recipes-oss/cpputest/cpputest.inc
+++ b/recipes-oss/cpputest/cpputest.inc
@@ -1,9 +1,0 @@
-SUMMARY = "CppUTest unit testing and mocking framework for C/C++"
-DESCRIPTION = "CppUTest is a C /C++ based unit xUnit test framework for unit testing and for test-driving your code. It is written in C++ but is used in C and C++ projects and frequently used in embedded systems but it works for any C/C++ project."
-AUTHOR = "CppUTest"
-HOMEPAGE = "https://github.com/cpputest/cpputest"
-BUGTRACKER = "https://github.com/cpputest/cpputest/issues"
-SECTION = "devel"
-LICENSE = "BSD-3-Clause"
-
-CVE_PRODUCT = ""

--- a/recipes-oss/cpputest/cpputest_4.0.bb
+++ b/recipes-oss/cpputest/cpputest_4.0.bb
@@ -1,19 +1,25 @@
-require ${PN}.inc
+SUMMARY = "CppUTest unit testing and mocking framework for C/C++"
+HOMEPAGE = "http://cpputest.github.io/"
+SECTION = "devel"
 
+LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://COPYING;md5=ce5d5f1fe02bcd1343ced64a06fd4177"
-SRC_URI = "https://github.com/cpputest/cpputest/releases/download/v${PV}/cpputest-${PV}.tar.gz"
-SRC_URI[sha256sum] = "21c692105db15299b5529af81a11a7ad80397f92c122bd7bf1e4a4b0e85654f7"
+
+SRC_URI = "git://github.com/cpputest/cpputest.git;protocol=https;branch=master"
+SRCREV = "67d2dfd41e13f09ff218aa08e2d35f1c32f032a1"
+
+S = "${WORKDIR}/git"
 
 inherit cmake
 
-EXTRA_OECMAKE = "\
-    -DC++11=ON \
-    -DTESTS=OFF \
-    -DLONGLONG=ON \
-"
+EXTRA_OECMAKE = "-DLONGLONG=ON \
+                 -DC++11=ON \
+                 -DTESTS=OFF \
+                 "
 
-FILES_${PN}-dev += "${libdir}/CppUTest/cmake/*"
+DEV_PKG_DEPENDENCY = ""
 
-ALLOW_EMPTY_${PN} = "1"
+FILES:${PN}-dev += "${libdir}/CppUTest/cmake/*"
 
-BBCLASSEXTEND = "native nativesdk"
+PACKAGECONFIG ??= ""
+PACKAGECONFIG[extensions] = "-DEXTENSIONS=ON,-DEXTENSIONS=OFF"

--- a/recipes-oss/nlohmann-json/backport.md
+++ b/recipes-oss/nlohmann-json/backport.md
@@ -1,3 +1,5 @@
 # Backport
 
 Available with *meta-oe > kirkstone (Yocto Project > 4.0)*.
+
+Upstream revision: `ca831e8d5b3d3e3d1612ae74c35dd73bef63e2b6`

--- a/recipes-oss/nlohmann-json/nlohmann-json_3.11.2.bb
+++ b/recipes-oss/nlohmann-json/nlohmann-json_3.11.2.bb
@@ -1,5 +1,3 @@
-# Upstream version: 502262820a4746ffd930dee350dcba176410edbb
-
 SUMMARY = "JSON for modern C++"
 HOMEPAGE = "https://nlohmann.github.io/json/"
 SECTION = "libs"


### PR DESCRIPTION
Updates recipes from latest meta-oe.

- Use CppUTest recipe which supports building extensions now
- Move revision out of nlohman-json so there's no diff to upstream (mentioned revision fixed)

The underlying issue of #95 might need some more work – not part of this PR though.