### PR TITLE
Update extra-cmake-modules and unbreak populate_sdk

### DIFF
--- a/recipes-core/images/protos-core-image-dev.bb
+++ b/recipes-core/images/protos-core-image-dev.bb
@@ -4,4 +4,8 @@ IMAGE_FEATURES += "dev-pkgs"
 IMAGE_FEATURES += "tools-sdk"
 IMAGE_FEATURES += "x11-base"
 
+TOOLCHAIN_TARGET_TASK_append = " \
+    nativesdk-extra-cmake-modules \
+"
+
 inherit core-image

--- a/recipes-devtools/extra-cmake-modules/extra-cmake-modules_5.100.0.bb
+++ b/recipes-devtools/extra-cmake-modules/extra-cmake-modules_5.100.0.bb
@@ -3,17 +3,17 @@ require ${PN}.inc
 LIC_FILES_CHKSUM = "file://COPYING-CMAKE-SCRIPTS;md5=54c7042be62e169199200bc6477f04d1"
 
 SRC_URI = "https://invent.kde.org/frameworks/${BPN}/-/archive/v${PV}/${BPN}-v${PV}.tar.gz"
-SRC_URI[sha256sum] = "99821e2479e2ef35440b6600801c1057dfaded18adf84904ecf0adc0dc9f34f2"
+SRC_URI[sha256sum] = "b5b63cc5e704182549155649dd6df73580660d5510acbb9c7567db448c80b1cd"
 
 S = "${WORKDIR}/${BPN}-v${PV}"
 
 EXTRA_OECMAKE += "-DBUILD_TESTING=off"
 
-inherit cmake
+inherit cmake_qt5
 
-PACKAGES = "${PN} ${PN}-dev"
+PACKAGES = "${PN}"
 
-FILES_${PN}-dev += "${datadir}/ECM"
+FILES_${PN} += "${datadir}/ECM"
 
 BBCLASSEXTEND = "native"
 


### PR DESCRIPTION
Allow adding extra-cmake-modules to SDK image and update to latest version 5.100.0.