### PR TITLE
Revert "Update cppcheck to 2.10"

### DIFF
--- a/recipes-oss/cppcheck/cppcheck_2.7.bb
+++ b/recipes-oss/cppcheck/cppcheck_2.7.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
 DEPENDS += "libpcre"
 
 SRC_URI = "git://github.com/danmar/cppcheck.git;protocol=https;nobranch=1"
-SRCREV = "74221fbc8dc9c5c64b22b6bd56e790724e41e0aa"
+SRCREV = "6ba6567ad897d56741159f8af90fc354ae050e61"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
This reverts commit a9239ec74ac885f4fb1fe00708e0aff63785c793 as it breaks x86 (32 bit) build.

https://github.com/jhnc-oss/meta-protos/issues/104