### PR TITLE
SDK: add weston and wayland sources to target

### DIFF
--- a/recipes-core/images/protos-core-image-dev.bb
+++ b/recipes-core/images/protos-core-image-dev.bb
@@ -15,6 +15,11 @@ TOOLCHAIN_HOST_TASK_append = "\
     nativesdk-libxft \
 "
 
+IMAGE_INSTALL_append = "\
+    weston \
+    wayland \
+"
+
 GCC_VERSION = "gcc93"
 
 TOOLCHAIN_OUTPUTNAME ?= "${DISTRO}-${SDKMACHINE}-toolchain-${GCC_VERSION}-${MACHINE}-${DISTRO_VERSION}"


### PR DESCRIPTION
closes (#112)

--- protos-x86_64-toolchain-gcc93-genericx86-64-3.1.21.target.manifest +++ protos-x86_64-toolchain-gcc93-genericx86-64-3.1.21.target.manifest @@ -917,6 +917,9 @@ libgl-mesa core2_64 20.0.2
 libgl-mesa-dev core2_64 20.0.2
 libglapi-dev core2_64 20.0.2
 libglapi0 core2_64 20.0.2
+libgles2-mesa core2_64 20.0.2
+libgles2-mesa-dev core2_64 20.0.2
+libgles3-mesa-dev core2_64 20.0.2
 libglib-2.0-0 core2_64 2.62.6
 libglib-2.0-dbg core2_64 2.62.6
 libglib-2.0-dev core2_64 2.62.6
@@ -1100,6 +1103,7 @@ libvorbis core2_64 1.3.6
 libvorbis-dbg core2_64 1.3.6
 libvorbis-dev core2_64 1.3.6
 libvte-2.91-0 core2_64 0.58.3
+libweston-8 core2_64 8.0.0
 libwrap-dev core2_64 7.6
 libwrap0 core2_64 7.6
 libx11-6 core2_64 1.6.9
@@ -1761,6 +1765,13 @@ wayland-dbg core2_64 1.18.0
 wayland-dev core2_64 1.18.0
 wayland-protocols noarch 1.20
 wayland-src core2_64 1.18.0
+weston core2_64 8.0.0
+weston-dbg core2_64 8.0.0
+weston-dev core2_64 8.0.0
+weston-init genericx86_64 1.0
+weston-init-dbg genericx86_64 1.0
+weston-init-dev genericx86_64 1.0
+weston-src core2_64 8.0.0
 which core2_64 2.21
 which-dev core2_64 2.21
 wireless-regdb-static noarch 2022.08.12