### PR TITLE
Update openssl to 3.0.8 (downstream requirement)

### DIFF
--- a/meta/recipes-connectivity/openssl/files/environment.d-openssl.sh
+++ b/meta/recipes-connectivity/openssl/files/environment.d-openssl.sh
@@ -1,0 +1,5 @@
+export OPENSSL_CONF="$OECORE_NATIVE_SYSROOT/usr/lib/ssl/openssl.cnf"
+export SSL_CERT_DIR="$OECORE_NATIVE_SYSROOT/usr/lib/ssl/certs"
+export SSL_CERT_FILE="$OECORE_NATIVE_SYSROOT/usr/lib/ssl/certs/ca-certificates.crt"
+export OPENSSL_MODULES="$OECORE_NATIVE_SYSROOT/usr/lib/ossl-modules/"
+export OPENSSL_ENGINES="$OECORE_NATIVE_SYSROOT/usr/lib/engines-3"

--- a/meta/recipes-connectivity/openssl/openssl/0001-Configure-do-not-tweak-mips-cflags.patch
+++ b/meta/recipes-connectivity/openssl/openssl/0001-Configure-do-not-tweak-mips-cflags.patch
@@ -1,0 +1,36 @@
+From 326909baf81a638d51fa8be1d8227518784f5cc4 Mon Sep 17 00:00:00 2001
+From: Alexander Kanavin <alex@linutronix.de>
+Date: Tue, 14 Sep 2021 12:18:25 +0200
+Subject: [PATCH] Configure: do not tweak mips cflags
+
+This conflicts with mips machine definitons from yocto,
+e.g.
+| Error: -mips3 conflicts with the other architecture options, which imply -mips64r2
+
+Upstream-Status: Inappropriate [oe-core specific]
+Signed-off-by: Alexander Kanavin <alex@linutronix.de>
+---
+ Configure | 10 ----------
+ 1 file changed, 10 deletions(-)
+
+Index: openssl-3.0.4/Configure
+===================================================================
+--- openssl-3.0.4.orig/Configure
++++ openssl-3.0.4/Configure
+@@ -1423,16 +1423,6 @@ if ($target =~ /^mingw/ && `$config{CC}
+         push @{$config{shared_ldflag}}, "-mno-cygwin";
+         }
+ 
+-if ($target =~ /linux.*-mips/ && !$disabled{asm}
+-        && !grep { $_ !~ /-m(ips|arch=)/ } (@{$config{CFLAGS}})) {
+-        # minimally required architecture flags for assembly modules
+-        my $value;
+-        $value = '-mips2' if ($target =~ /mips32/);
+-        $value = '-mips3' if ($target =~ /mips64/);
+-        unshift @{$config{cflags}}, $value;
+-        unshift @{$config{cxxflags}}, $value if $config{CXX};
+-}
+-
+ # If threads aren't disabled, check how possible they are
+ unless ($disabled{threads}) {
+     if ($auto_threads) {

--- a/meta/recipes-connectivity/openssl/openssl/0001-buildinfo-strip-sysroot-and-debug-prefix-map-from-co.patch
+++ b/meta/recipes-connectivity/openssl/openssl/0001-buildinfo-strip-sysroot-and-debug-prefix-map-from-co.patch
@@ -1,0 +1,78 @@
+From 5985253f2c9025d7c127443a3a9938946f80c2a1 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Martin=20Hundeb=C3=B8ll?= <martin@geanix.com>
+Date: Tue, 6 Nov 2018 14:50:47 +0100
+Subject: [PATCH] buildinfo: strip sysroot and debug-prefix-map from compiler
+ info
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The openssl build system generates buildinf.h containing the full
+compiler command line used to compile objects. This breaks
+reproducibility, as the compile command is baked into libcrypto, where
+it is used when running `openssl version -f`.
+
+Add stripped build variables for the compiler and cflags lines, and use
+those when generating buildinfo.h.
+
+This is based on a similar patch for older openssl versions:
+https://patchwork.openembedded.org/patch/147229/
+
+Upstream-Status: Inappropriate [OE specific]
+Signed-off-by: Martin Hundebøll <martin@geanix.com>
+
+Update to fix buildpaths qa issue for '-fmacro-prefix-map'.
+
+Signed-off-by: Kai Kang <kai.kang@windriver.com>
+
+Update to fix buildpaths qa issue for '-ffile-prefix-map'.
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+
+---
+ Configurations/unix-Makefile.tmpl | 12 +++++++++++-
+ crypto/build.info                 |  2 +-
+ 2 files changed, 12 insertions(+), 2 deletions(-)
+
+Index: openssl-3.0.4/Configurations/unix-Makefile.tmpl
+===================================================================
+--- openssl-3.0.4.orig/Configurations/unix-Makefile.tmpl
++++ openssl-3.0.4/Configurations/unix-Makefile.tmpl
+@@ -472,13 +472,23 @@ BIN_LDFLAGS={- join(' ', $target{bin_lfl
+                          '$(CNF_LDFLAGS)', '$(LDFLAGS)') -}
+ BIN_EX_LIBS=$(CNF_EX_LIBS) $(EX_LIBS)
+ 
+-# CPPFLAGS_Q is used for one thing only: to build up buildinf.h
++# *_Q variables are used for one thing only: to build up buildinf.h
+ CPPFLAGS_Q={- $cppflags1 =~ s|([\\"])|\\$1|g;
+               $cppflags2 =~ s|([\\"])|\\$1|g;
+               $lib_cppflags =~ s|([\\"])|\\$1|g;
+               join(' ', $lib_cppflags || (), $cppflags2 || (),
+                         $cppflags1 || ()) -}
+ 
++CFLAGS_Q={- for (@{$config{CFLAGS}}) {
++              s|-fdebug-prefix-map=[^ ]+|-fdebug-prefix-map=|g;
++              s|-fmacro-prefix-map=[^ ]+|-fmacro-prefix-map=|g;
++              s|-ffile-prefix-map=[^ ]+|-ffile-prefix-map=|g;
++            }
++            join(' ', @{$config{CFLAGS}}) -}
++
++CC_Q={- $config{CC} =~ s|--sysroot=[^ ]+|--sysroot=recipe-sysroot|g;
++        join(' ', $config{CC}) -}
++
+ PERLASM_SCHEME= {- $target{perlasm_scheme} -}
+ 
+ # For x86 assembler: Set PROCESSOR to 386 if you want to support
+Index: openssl-3.0.4/crypto/build.info
+===================================================================
+--- openssl-3.0.4.orig/crypto/build.info
++++ openssl-3.0.4/crypto/build.info
+@@ -109,7 +109,7 @@ DEFINE[../libcrypto]=$UPLINKDEF
+ 
+ DEPEND[info.o]=buildinf.h
+ DEPEND[cversion.o]=buildinf.h
+-GENERATE[buildinf.h]=../util/mkbuildinf.pl "$(CC) $(LIB_CFLAGS) $(CPPFLAGS_Q)" "$(PLATFORM)"
++GENERATE[buildinf.h]=../util/mkbuildinf.pl "$(CC_Q) $(CFLAGS_Q) $(CPPFLAGS_Q)" "$(PLATFORM)"
+ 
+ GENERATE[uplink-x86.S]=../ms/uplink-x86.pl
+ GENERATE[uplink-x86_64.s]=../ms/uplink-x86_64.pl

--- a/meta/recipes-connectivity/openssl/openssl/afalg.patch
+++ b/meta/recipes-connectivity/openssl/openssl/afalg.patch
@@ -1,0 +1,31 @@
+Don't refuse to build afalgeng if cross-compiling or the host kernel is too old.
+
+Upstream-Status: Submitted [hhttps://github.com/openssl/openssl/pull/7688]
+Signed-off-by: Ross Burton <ross.burton@intel.com>
+
+Index: openssl-3.0.4/Configure
+===================================================================
+--- openssl-3.0.4.orig/Configure
++++ openssl-3.0.4/Configure
+@@ -1681,20 +1681,7 @@ $config{CFLAGS} = [ map { $_ eq '--ossl-
+ unless ($disabled{afalgeng}) {
+     $config{afalgeng}="";
+     if (grep { $_ eq 'afalgeng' } @{$target{enable}}) {
+-        my $minver = 4*10000 + 1*100 + 0;
+-        if ($config{CROSS_COMPILE} eq "") {
+-            my $verstr = `uname -r`;
+-            my ($ma, $mi1, $mi2) = split("\\.", $verstr);
+-            ($mi2) = $mi2 =~ /(\d+)/;
+-            my $ver = $ma*10000 + $mi1*100 + $mi2;
+-            if ($ver < $minver) {
+-                disable('too-old-kernel', 'afalgeng');
+-            } else {
+-                push @{$config{engdirs}}, "afalg";
+-            }
+-        } else {
+-            disable('cross-compiling', 'afalgeng');
+-        }
++        push @{$config{engdirs}}, "afalg";
+     } else {
+         disable('not-linux', 'afalgeng');
+     }

--- a/meta/recipes-connectivity/openssl/openssl/run-ptest
+++ b/meta/recipes-connectivity/openssl/openssl/run-ptest
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e
+
+# Optional arguments are 'list' to lists all tests, or the test name (base name
+# ie test_evp, not 03_test_evp.t).
+
+export TOP=.
+# OPENSSL_ENGINES is relative from the test binaries
+export OPENSSL_ENGINES=../engines
+
+perl ./test/run_tests.pl $* | sed -u -r -e '/(.*) \.*.ok/ s/^/PASS: /g' -r -e '/Dubious(.*)/ s/^/FAIL: /g' -e '/(.*) \.*.skipped: (.*)/ s/^/SKIP: /g'

--- a/meta/recipes-connectivity/openssl/openssl_3.0.8.bb
+++ b/meta/recipes-connectivity/openssl/openssl_3.0.8.bb
@@ -1,0 +1,258 @@
+SUMMARY = "Secure Socket Layer"
+DESCRIPTION = "Secure Socket Layer (SSL) binary and related cryptographic tools."
+HOMEPAGE = "http://www.openssl.org/"
+BUGTRACKER = "http://www.openssl.org/news/vulnerabilities.html"
+SECTION = "libs/network"
+
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=c75985e733726beaba57bc5253e96d04"
+
+SRC_URI = "http://www.openssl.org/source/openssl-${PV}.tar.gz \
+           file://run-ptest \
+           file://0001-buildinfo-strip-sysroot-and-debug-prefix-map-from-co.patch \
+           file://afalg.patch \
+           file://0001-Configure-do-not-tweak-mips-cflags.patch \
+           "
+
+SRC_URI:append:class-nativesdk = " \
+           file://environment.d-openssl.sh \
+           "
+
+SRC_URI[sha256sum] = "6c13d2bf38fdf31eac3ce2a347073673f5d63263398f1f69d0df4a41253e4b3e"
+
+inherit lib_package multilib_header multilib_script ptest perlnative
+MULTILIB_SCRIPTS = "${PN}-bin:${bindir}/c_rehash"
+
+PACKAGECONFIG ?= ""
+PACKAGECONFIG:class-native = ""
+PACKAGECONFIG:class-nativesdk = ""
+
+PACKAGECONFIG[cryptodev-linux] = "enable-devcryptoeng,disable-devcryptoeng,cryptodev-linux,,cryptodev-module"
+PACKAGECONFIG[no-tls1] = "no-tls1"
+PACKAGECONFIG[no-tls1_1] = "no-tls1_1"
+
+B = "${WORKDIR}/build"
+do_configure[cleandirs] = "${B}"
+
+#| ./libcrypto.so: undefined reference to `getcontext'
+#| ./libcrypto.so: undefined reference to `setcontext'
+#| ./libcrypto.so: undefined reference to `makecontext'
+EXTRA_OECONF:append:libc-musl = " no-async"
+EXTRA_OECONF:append:libc-musl:powerpc64 = " no-asm"
+
+# adding devrandom prevents openssl from using getrandom() which is not available on older glibc versions
+# (native versions can be built with newer glibc, but then relocated onto a system with older glibc)
+EXTRA_OECONF:class-native = "--with-rand-seed=os,devrandom"
+EXTRA_OECONF:class-nativesdk = "--with-rand-seed=os,devrandom"
+
+# Relying on hardcoded built-in paths causes openssl-native to not be relocateable from sstate.
+CFLAGS:append:class-native = " -DOPENSSLDIR=/not/builtin -DENGINESDIR=/not/builtin"
+CFLAGS:append:class-nativesdk = " -DOPENSSLDIR=/not/builtin -DENGINESDIR=/not/builtin"
+
+# This allows disabling deprecated or undesirable crypto algorithms.
+# The default is to trust upstream choices.
+DEPRECATED_CRYPTO_FLAGS ?= ""
+
+do_configure () {
+	# When we upgrade glibc but not uninative we see obtuse failures in openssl. Make
+	# the issue really clear that perl isn't functional due to symbol mismatch issues.
+	cat <<- EOF > ${WORKDIR}/perltest
+	#!/usr/bin/env perl
+	use POSIX;
+	EOF
+	chmod a+x ${WORKDIR}/perltest
+	${WORKDIR}/perltest
+
+	os=${HOST_OS}
+	case $os in
+	linux-gnueabi |\
+	linux-gnuspe |\
+	linux-musleabi |\
+	linux-muslspe |\
+	linux-musl )
+		os=linux
+		;;
+	*)
+		;;
+	esac
+	target="$os-${HOST_ARCH}"
+	case $target in
+	linux-arc)
+		target=linux-latomic
+		;;
+	linux-arm*)
+		target=linux-armv4
+		;;
+	linux-aarch64*)
+		target=linux-aarch64
+		;;
+	linux-i?86 | linux-viac3)
+		target=linux-x86
+		;;
+	linux-gnux32-x86_64 | linux-muslx32-x86_64 )
+		target=linux-x32
+		;;
+	linux-gnu64-x86_64)
+		target=linux-x86_64
+		;;
+	linux-mips | linux-mipsel)
+		# specifying TARGET_CC_ARCH prevents openssl from (incorrectly) adding target architecture flags
+		target="linux-mips32 ${TARGET_CC_ARCH}"
+		;;
+	linux-gnun32-mips*)
+		target=linux-mips64
+		;;
+	linux-*-mips64 | linux-mips64 | linux-*-mips64el | linux-mips64el)
+		target=linux64-mips64
+		;;
+	linux-microblaze* | linux-nios2* | linux-sh3 | linux-sh4 | linux-arc*)
+		target=linux-generic32
+		;;
+	linux-powerpc)
+		target=linux-ppc
+		;;
+	linux-powerpc64)
+		target=linux-ppc64
+		;;
+	linux-powerpc64le)
+		target=linux-ppc64le
+		;;
+	linux-riscv32)
+		target=linux-generic32
+		;;
+	linux-riscv64)
+		target=linux-generic64
+		;;
+	linux-sparc | linux-supersparc)
+		target=linux-sparcv9
+		;;
+	mingw32-x86_64)
+		target=mingw64
+		;;
+	esac
+
+	useprefix=${prefix}
+	if [ "x$useprefix" = "x" ]; then
+		useprefix=/
+	fi
+	# WARNING: do not set compiler/linker flags (-I/-D etc.) in EXTRA_OECONF, as they will fully replace the
+	# environment variables set by bitbake. Adjust the environment variables instead.
+	HASHBANGPERL="/usr/bin/env perl" PERL=perl PERL5LIB="${S}/external/perl/Text-Template-1.46/lib/" \
+	perl ${S}/Configure ${EXTRA_OECONF} ${PACKAGECONFIG_CONFARGS} ${DEPRECATED_CRYPTO_FLAGS} --prefix=$useprefix --openssldir=${libdir}/ssl-3 --libdir=${libdir} $target
+	perl ${B}/configdata.pm --dump
+}
+
+do_install () {
+	oe_runmake DESTDIR="${D}" MANDIR="${mandir}" MANSUFFIX=ssl install
+
+	oe_multilib_header openssl/opensslconf.h
+	oe_multilib_header openssl/configuration.h
+
+	# Create SSL structure for packages such as ca-certificates which
+	# contain hard-coded paths to /etc/ssl. Debian does the same.
+	install -d ${D}${sysconfdir}/ssl
+	mv ${D}${libdir}/ssl-3/certs \
+	   ${D}${libdir}/ssl-3/private \
+	   ${D}${libdir}/ssl-3/openssl.cnf \
+	   ${D}${sysconfdir}/ssl/
+
+	# Although absolute symlinks would be OK for the target, they become
+	# invalid if native or nativesdk are relocated from sstate.
+	ln -sf ${@oe.path.relative('${libdir}/ssl-3', '${sysconfdir}/ssl/certs')} ${D}${libdir}/ssl-3/certs
+	ln -sf ${@oe.path.relative('${libdir}/ssl-3', '${sysconfdir}/ssl/private')} ${D}${libdir}/ssl-3/private
+	ln -sf ${@oe.path.relative('${libdir}/ssl-3', '${sysconfdir}/ssl/openssl.cnf')} ${D}${libdir}/ssl-3/openssl.cnf
+}
+
+do_install:append:class-native () {
+	create_wrapper ${D}${bindir}/openssl \
+	    OPENSSL_CONF=${libdir}/ssl-3/openssl.cnf \
+	    SSL_CERT_DIR=${libdir}/ssl-3/certs \
+	    SSL_CERT_FILE=${libdir}/ssl-3/cert.pem \
+	    OPENSSL_ENGINES=${libdir}/engines-3 \
+	    OPENSSL_MODULES=${libdir}/ossl-modules
+}
+
+do_install:append:class-nativesdk () {
+	mkdir -p ${D}${SDKPATHNATIVE}/environment-setup.d
+	install -m 644 ${WORKDIR}/environment.d-openssl.sh ${D}${SDKPATHNATIVE}/environment-setup.d/openssl.sh
+	sed 's|/usr/lib/ssl/|/usr/lib/ssl-3/|g' -i ${D}${SDKPATHNATIVE}/environment-setup.d/openssl.sh
+}
+
+PTEST_BUILD_HOST_FILES += "configdata.pm"
+PTEST_BUILD_HOST_PATTERN = "perl_version ="
+do_install_ptest () {
+	install -d ${D}${PTEST_PATH}/test
+	install -m755 ${B}/test/p_test.so ${D}${PTEST_PATH}/test
+	install -m755 ${B}/test/provider_internal_test.cnf ${D}${PTEST_PATH}/test
+
+	# Prune the build tree
+	rm -f ${B}/fuzz/*.* ${B}/test/*.*
+
+	cp ${S}/Configure ${B}/configdata.pm ${D}${PTEST_PATH}
+	sed 's|${S}|${PTEST_PATH}|g' -i ${D}${PTEST_PATH}/configdata.pm
+	cp -r ${S}/external ${B}/test ${S}/test ${B}/fuzz ${S}/util ${B}/util ${D}${PTEST_PATH}
+
+	# For test_shlibload
+	ln -s ${libdir}/libcrypto.so.1.1 ${D}${PTEST_PATH}/
+	ln -s ${libdir}/libssl.so.1.1 ${D}${PTEST_PATH}/
+
+	install -d ${D}${PTEST_PATH}/apps
+	ln -s ${bindir}/openssl ${D}${PTEST_PATH}/apps
+	install -m644 ${S}/apps/*.pem ${S}/apps/*.srl ${S}/apps/openssl.cnf ${D}${PTEST_PATH}/apps
+	install -m755 ${B}/apps/CA.pl ${D}${PTEST_PATH}/apps
+
+	install -d ${D}${PTEST_PATH}/engines
+	install -m755 ${B}/engines/dasync.so ${D}${PTEST_PATH}/engines
+	install -m755 ${B}/engines/loader_attic.so ${D}${PTEST_PATH}/engines
+	install -m755 ${B}/engines/ossltest.so ${D}${PTEST_PATH}/engines
+
+	install -d ${D}${PTEST_PATH}/providers
+	install -m755 ${B}/providers/legacy.so ${D}${PTEST_PATH}/providers
+
+	install -d ${D}${PTEST_PATH}/Configurations
+	cp -rf ${S}/Configurations/* ${D}${PTEST_PATH}/Configurations/
+
+	# seems to be needed with perl 5.32.1
+	install -d ${D}${PTEST_PATH}/util/perl/recipes
+	cp ${D}${PTEST_PATH}/test/recipes/tconversion.pl ${D}${PTEST_PATH}/util/perl/recipes/
+
+	sed 's|${S}|${PTEST_PATH}|g' -i ${D}${PTEST_PATH}/util/wrap.pl
+}
+
+# Add the openssl.cnf file to the openssl-conf package. Make the libcrypto
+# package RRECOMMENDS on this package. This will enable the configuration
+# file to be installed for both the openssl-bin package and the libcrypto
+# package since the openssl-bin package depends on the libcrypto package.
+
+PACKAGES =+ "libcrypto libssl openssl-conf ${PN}-engines ${PN}-misc ${PN}-ossl-module-legacy"
+
+FILES:libcrypto = "${libdir}/libcrypto${SOLIBS}"
+FILES:libssl = "${libdir}/libssl${SOLIBS}"
+FILES:openssl-conf = "${sysconfdir}/ssl/openssl.cnf \
+                      ${libdir}/ssl-3/openssl.cnf* \
+                      "
+FILES:${PN}-engines = "${libdir}/engines-3"
+# ${prefix} comes from what we pass into --prefix at configure time (which is used for INSTALLTOP)
+FILES:${PN}-engines:append:mingw32:class-nativesdk = " ${prefix}${libdir}/engines-3"
+FILES:${PN}-misc = "${libdir}/ssl-3/misc ${bindir}/c_rehash"
+FILES:${PN}-ossl-module-legacy = "${libdir}/ossl-modules/legacy.so"
+FILES:${PN} =+ "${libdir}/ssl-3/* ${libdir}/ossl-modules/"
+FILES:${PN}:append:class-nativesdk = " ${SDKPATHNATIVE}/environment-setup.d/openssl.sh"
+
+CONFFILES:openssl-conf = "${sysconfdir}/ssl/openssl.cnf"
+
+RRECOMMENDS:libcrypto += "openssl-conf ${PN}-ossl-module-legacy"
+RDEPENDS:${PN}-misc = "perl"
+RDEPENDS:${PN}-ptest += "openssl-bin perl perl-modules bash sed"
+
+RDEPENDS:${PN}-bin += "openssl-conf"
+
+BBCLASSEXTEND = "native nativesdk"
+
+CVE_PRODUCT = "openssl:openssl"
+
+CVE_VERSION_SUFFIX = "alphabetical"
+
+# Only affects OpenSSL >= 1.1.1 in combination with Apache < 2.4.37
+# Apache in meta-webserver is already recent enough
+CVE_CHECK_IGNORE += "CVE-2019-0190"


### PR DESCRIPTION
Update openssl to 3.0.8 which addresses a HIGH level security issue and a couple of MEDIUM security issues.

Please refer to https://www.openssl.org/news/secadv/20230207.txt for further information.