### PR TITLE
Add Catch v3.3.2

### DIFF
--- a/recipes-test/catch3/catch3.inc
+++ b/recipes-test/catch3/catch3.inc
@@ -1,0 +1,10 @@
+SUMMARY = "A modern, C++-native, test framework for unit-tests, TDD and BDD"
+DESCRIPTION = "Catch2 is mainly a unit testing framework for C++, but it also provides basic micro-benchmarking features, and simple BDD macros."
+AUTHOR = "Catch"
+HOMEPAGE = "https://github.com/catchorg/Catch2"
+BUGTRACKER = "https://github.com/catchorg/Catch2/issues"
+SECTION = "development"
+LICENSE = "BSL-1.0"
+
+CVE_PRODUCT = ""
+

--- a/recipes-test/catch3/catch3_3.3.2.bb
+++ b/recipes-test/catch3/catch3_3.3.2.bb
@@ -1,0 +1,17 @@
+require ${PN}.inc
+
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=e4224ccaecb14d942c71d31bef20d78c"
+
+SRC_URI = "git://github.com/catchorg/Catch2.git;protocol=https;nobranch=1"
+SRCREV = "3f0283de7a9c43200033da996ff9093be3ac84dc"
+
+S = "${WORKDIR}/git"
+
+inherit cmake
+
+do_install_append() {
+    rm -rf ${D}${datadir}/Catch2
+}
+
+BBCLASSEXTEND = "native nativesdk"
+

--- a/recipes-test/packagegroups/packagegroup-protos-test.bb
+++ b/recipes-test/packagegroups/packagegroup-protos-test.bb
@@ -1,0 +1,7 @@
+SUMMARY = "Protos test libraries"
+
+inherit packagegroup
+
+RDEPEND_${PN} = "\
+    catch3 \
+"


### PR DESCRIPTION
Adds Catch v3.x (#129).

~~The recipe path follows *meta-oe* – which still ships v2 on master.~~