### PR TITLE
Set allow empty for Catch v3

### DIFF
--- a/recipes-test/catch3/catch3_3.3.2.bb
+++ b/recipes-test/catch3/catch3_3.3.2.bb
@@ -13,5 +13,7 @@ do_install_append() {
     rm -rf ${D}${datadir}/Catch2
 }
 
+ALLOW_EMPTY_${PN} = "1"
+
 BBCLASSEXTEND = "native nativesdk"
 


### PR DESCRIPTION
Allow empty is necessary for SDK inclusion.