### PR TITLE
Fix debugpy x86 build

### DIFF
--- a/recipes-oss/debugpy/debugpy_1.6.0.bb
+++ b/recipes-oss/debugpy/debugpy_1.6.0.bb
@@ -15,7 +15,7 @@ PYPI_PACKAGE = "debugpy"
 PYPI_PACKAGE_EXT = "zip"
 
 def get_so_target(d):
-    if d.getVar('YOCTO_TARGET_ARCH') == 'x86':
+    if d.getVar('MACHINE_ARCH') == 'genericx86':
         return 'attach_linux_x86'
     return 'attach_linux_amd64'
 


### PR DESCRIPTION
Recipe debugpy was using an obsolete environment setting which is no longer in use.