### PR TITLE
Update CppUTest backport descritpion

### DIFF
--- a/recipes-oss/cpputest/backport.md
+++ b/recipes-oss/cpputest/backport.md
@@ -1,5 +1,5 @@
 # Backport
 
-Available with *meta-oe > honister (Yocto Project > 3.4)*.
+Available with *meta-oe > mickledore (Yocto Project 4.2)*.
 
 Upstream revision: `8c0402f7c47188cef1d6afc68c0427124940ea57`


### PR DESCRIPTION
While v4.0 is available with honister, the extension support was added in mickledore.