### PR TITLE
Update Cppcheck v2.11.1

### DIFF
--- a/recipes-oss/cppcheck/cppcheck_2.11.1.bb
+++ b/recipes-oss/cppcheck/cppcheck_2.11.1.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
 DEPENDS += "libpcre"
 
 SRC_URI = "git://github.com/danmar/cppcheck.git;protocol=https;nobranch=1"
-SRCREV = "6ba6567ad897d56741159f8af90fc354ae050e61"
+SRCREV = "13746898140fa229018b57acdb18091942c8ea05"
 
 S = "${WORKDIR}/git"
 
@@ -12,9 +12,10 @@ inherit cmake
 
 EXTRA_OECMAKE = "\
     -DBUILD_GUI=OFF \
-    -DUSE_MATCHCOMPILER=ON \
-    -DHAVE_RULES=ON \
     -DBUILD_TESTS=OFF \
+    -DDISABLE_DMAKE=ON \
+    -DHAVE_RULES=ON \
+    -DUSE_MATCHCOMPILER=ON \
 "
 
 FILES_${PN} += "${datadir}/Cppcheck/"


### PR DESCRIPTION
Updates Cppcheck to v2.11.1 (#142).

2.11 introduced an option to to disable build steps, which caused a broken build on some architectures (#104).