### PR TITLE
Sync 'main' to 'kirkstone' LTS branch

### DIFF
--- a/.github/workflows/sync-main.yml
+++ b/.github/workflows/sync-main.yml
@@ -1,0 +1,19 @@
+name: sync-main
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  sync_to_lts:
+    runs-on: ubuntu-latest
+    name: "Sync 'main' to lts branch"
+    steps:
+      - uses: jojomatik/sync-branch@v1
+        with:
+          source: "main"
+          target: "kirkstone"
+          strategy: "fail"


### PR DESCRIPTION
Sync `main` to the current LTS branch (`kirkstone` at the moment); fail on merge conflicts.

:warning: *Kirkstone* related contributions should be merged to `main`, which is then synced to the related branch. I'm going to note this on #155 as well.