### PR TITLE
pytest backport

### DIFF
--- a/recipes-devtools/python/backport.md
+++ b/recipes-devtools/python/backport.md
@@ -1,0 +1,7 @@
+# Backport
+
+## python3-pytest
+
+Available with *openembedded-core > mickledore (Yocto Project 4.2)*.
+
+Upstream revision: `272f6ac29246c67c8ed1ed685ab2c0631fc5fbe3` *(modified for compatibility)*

--- a/recipes-devtools/python/python3-pytest_7.4.0.bb
+++ b/recipes-devtools/python/python3-pytest_7.4.0.bb
@@ -1,0 +1,41 @@
+SUMMARY = "Simple powerful testing with python"
+HOMEPAGE = "https://pypi.org/project/pytest/"
+DESCRIPTION = "The pytest framework makes it easy to write small tests, yet scales to support complex functional testing for applications and libraries."
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=bd27e41b6550fe0fc45356d1d81ee37c"
+
+SRC_URI[sha256sum] = "b4bf8c45bd59934ed84001ad51e11b4ee40d40a1229d2c79f9c592b0a3f6bd8a"
+
+inherit update-alternatives pypi setuptools3
+
+DEPENDS += "python3-setuptools-scm-native"
+
+RDEPENDS:${PN} += " \
+    ${PYTHON_PN}-atomicwrites \
+    ${PYTHON_PN}-attrs \
+    ${PYTHON_PN}-debugger \
+    ${PYTHON_PN}-doctest \
+    ${PYTHON_PN}-importlib-metadata \
+    ${PYTHON_PN}-iniconfig \
+    ${PYTHON_PN}-json \
+    ${PYTHON_PN}-more-itertools \
+    ${PYTHON_PN}-packaging \
+    ${PYTHON_PN}-pathlib2 \
+    ${PYTHON_PN}-pluggy \
+    ${PYTHON_PN}-py \
+    ${PYTHON_PN}-setuptools \
+    ${PYTHON_PN}-six \
+    ${PYTHON_PN}-tomli \
+    ${PYTHON_PN}-wcwidth \
+"
+
+ALTERNATIVE:${PN} += "py.test pytest"
+
+NATIVE_LINK_NAME[pytest] = "${bindir}/pytest"
+ALTERNATIVE_TARGET[pytest] = "${bindir}/pytest"
+
+ALTERNATIVE_LINK_NAME[py.test] = "${bindir}/py.test"
+ALTERNATIVE_TARGET[py.test] = "${bindir}/py.test"
+
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
The main / kirkstone part of #154.

Unlike #163, no other backports are needed, dependencies are available upstream already.