### PR TITLE
Update CppCheck v2.12.0

### DIFF
--- a/recipes-oss/cppcheck/cppcheck_2.12.0.bb
+++ b/recipes-oss/cppcheck/cppcheck_2.12.0.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
 DEPENDS += "libpcre"
 
 SRC_URI = "git://github.com/danmar/cppcheck.git;protocol=https;nobranch=1"
-SRCREV = "13746898140fa229018b57acdb18091942c8ea05"
+SRCREV = "f2f1fb0bca5f23aac8f02fb9c09e4529a7935749"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Updates CppCheck to latest v2.12.0 (#171).