### PR TITLE
Update Catch v3.4.0 

### DIFF
--- a/recipes-test/catch3/catch3_3.4.0.bb
+++ b/recipes-test/catch3/catch3_3.4.0.bb
@@ -3,7 +3,7 @@ require ${PN}.inc
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=e4224ccaecb14d942c71d31bef20d78c"
 
 SRC_URI = "git://github.com/catchorg/Catch2.git;protocol=https;nobranch=1"
-SRCREV = "3f0283de7a9c43200033da996ff9093be3ac84dc"
+SRCREV = "6e79e682b726f524310d55dec8ddac4e9c52fb5f"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Updates Catch to v3.4.0 (#178).

This is main / kirkstone only, no plans to backport to dunfell for now.