### PR TITLE
Add missing python3-js2py dependencies

### DIFF
--- a/meta-python/recipes-devtools/python3-js2py/python3-js2py_0.74.bb
+++ b/meta-python/recipes-devtools/python3-js2py/python3-js2py_0.74.bb
@@ -4,9 +4,15 @@ LIC_FILES_CHKSUM = "file://LICENSE.md;md5=faa744092d3fb3314632e815e7c3a560"
 
 SRC_URI[sha256sum] = "39f3a6aa8469180efba3c8677271df27c31332fd1b471df1af2af58b87b8972f"
 
-PYPI_PACKAGE = "Js2Py"
-
 inherit pypi setuptools3
+
+RDEPENDS:${PN} += "\
+    python3-pyjsparser \
+    python3-six \
+    python3-tzlocal \
+"
+
+PYPI_PACKAGE = "Js2Py"
 
 BBCLASSEXTEND = "native nativesdk"
 

--- a/meta-python/recipes-devtools/python3-pyjsparser/python3-pyjsparser.inc
+++ b/meta-python/recipes-devtools/python3-pyjsparser/python3-pyjsparser.inc
@@ -1,0 +1,9 @@
+SUMMARY = "Fast JavaScript parser for Python."
+DESCRIPTION = "Fast JavaScript parser - manual translation of esprima.js to python. Takes 1 second to parse whole angular.js library so parsing speed is about 100k characters per second which makes it the fastest and most comprehensible JavaScript parser for python out there."
+AUTHOR = "Piotr Dabkowski <piodrus@gmail.com>"
+HOMEPAGE = "https://github.com/PiotrDabkowski/pyjsparser"
+BUGTRACKER = "https://github.com/PiotrDabkowski/pyjsparser/issues"
+SECTION = "development"
+LICENSE = "MIT"
+
+CVE_PRODUCT = ""

--- a/meta-python/recipes-devtools/python3-pyjsparser/python3-pyjsparser/LICENSE
+++ b/meta-python/recipes-devtools/python3-pyjsparser/python3-pyjsparser/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Piotr Dabkowski
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/meta-python/recipes-devtools/python3-pyjsparser/python3-pyjsparser_2.7.1.bb
+++ b/meta-python/recipes-devtools/python3-pyjsparser/python3-pyjsparser_2.7.1.bb
@@ -1,0 +1,13 @@
+require ${PN}.inc
+
+# The project doesn't ship the license
+LIC_FILES_CHKSUM = "file://${WORKDIR}/LICENSE;md5=953430a448a7e6837e6d8984fce682d1"
+
+SRC_URI_append = " file://LICENSE"
+SRC_URI[sha256sum] = "be60da6b778cc5a5296a69d8e7d614f1f870faf94e1b1b6ac591f2ad5d729579"
+
+PYPI_PACKAGE = "pyjsparser"
+
+inherit pypi setuptools3
+
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
Add missing python3-js2py dependencies (#184).

Note: pyjsparser doesn't include the license file in it's packages, thus the workaround.
