### PR TITLE
PyTest 7.4.4 update and fixes

### DIFF
--- a/meta-python/recipes-core/packagegroups/packagegroup-protos-python.bb
+++ b/meta-python/recipes-core/packagegroups/packagegroup-protos-python.bb
@@ -4,5 +4,6 @@ inherit packagegroup
 
 RDEPENDS:${PN} = "\
     python3-crudini \
+    python3-exceptiongroup \
     python3-uinput \
 "

--- a/meta-python/recipes-devtools/python3-exceptiongroup/python3-exceptiongroup.inc
+++ b/meta-python/recipes-devtools/python3-exceptiongroup/python3-exceptiongroup.inc
@@ -1,0 +1,10 @@
+SUMMARY = "Backport of PEP 654 (exception groups)"
+DESCRIPTION = "This is a backport of the BaseExceptionGroup and ExceptionGroup classes from Python 3.11."
+AUTHOR = "Alex Grönholm <alex.gronholm@nextday.fi>"
+HOMEPAGE = "https://github.com/agronholm/exceptiongroup"
+BUGTRACKER = "https://github.com/agronholm/exceptiongroup/issues"
+SECTION = "development"
+LICENSE = "MIT"
+
+CVE_PRODUCT = ""
+

--- a/meta-python/recipes-devtools/python3-exceptiongroup/python3-exceptiongroup_1.2.0.bb
+++ b/meta-python/recipes-devtools/python3-exceptiongroup/python3-exceptiongroup_1.2.0.bb
@@ -1,0 +1,12 @@
+require ${PN}.inc
+
+LIC_FILES_CHKSUM = "file://LICENSE;md5=d5caa317463c433575efff1d2fe206d7"
+
+SRC_URI[sha256sum] = "91f5c769735f051a4290d52edd0858999b57e5876e9f85937691bd4c9fa3ed68"
+
+inherit pypi python_flit_core
+
+PYPI_PACKAGE = "exceptiongroup"
+
+BBCLASSEXTEND = "native nativesdk"
+

--- a/recipes-devtools/python/backport.md
+++ b/recipes-devtools/python/backport.md
@@ -4,4 +4,4 @@
 
 Available with *openembedded-core > mickledore (Yocto Project 4.2)*.
 
-Upstream revision: `272f6ac29246c67c8ed1ed685ab2c0631fc5fbe3` *(modified for compatibility)*
+Upstream revision: `272f6ac29246c67c8ed1ed685ab2c0631fc5fbe3` *(updated / modified for compatibility)*

--- a/recipes-devtools/python/python3-pytest_7.4.0.bb
+++ b/recipes-devtools/python/python3-pytest_7.4.0.bb
@@ -16,6 +16,7 @@ RDEPENDS:${PN} += " \
     ${PYTHON_PN}-attrs \
     ${PYTHON_PN}-debugger \
     ${PYTHON_PN}-doctest \
+    ${PYTHON_PN}-exceptiongroup \
     ${PYTHON_PN}-importlib-metadata \
     ${PYTHON_PN}-iniconfig \
     ${PYTHON_PN}-json \

--- a/recipes-devtools/python/python3-pytest_7.4.4.bb
+++ b/recipes-devtools/python/python3-pytest_7.4.4.bb
@@ -5,13 +5,13 @@ DESCRIPTION = "The pytest framework makes it easy to write small tests, yet scal
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=bd27e41b6550fe0fc45356d1d81ee37c"
 
-SRC_URI[sha256sum] = "b4bf8c45bd59934ed84001ad51e11b4ee40d40a1229d2c79f9c592b0a3f6bd8a"
+DEPENDS += "python3-setuptools-scm-native"
+
+SRC_URI[sha256sum] = "2cf0005922c6ace4a3e2ec8b4080eb0d9753fdc93107415332f50ce9e7994280"
 
 inherit update-alternatives pypi setuptools3
 
-DEPENDS += "python3-setuptools-scm-native"
-
-RDEPENDS:${PN} += " \
+RDEPENDS:${PN} += "\
     ${PYTHON_PN}-atomicwrites \
     ${PYTHON_PN}-attrs \
     ${PYTHON_PN}-debugger \


### PR DESCRIPTION
Updates PyTest to 7.4.4 (#206) and adds the missing exceptiongroup dependency (#205, #207).