### PR TITLE
Fix obsolete spdx license identifier

### DIFF
--- a/meta-python/recipes-devtools/python3-paramiko/python3-paramiko.inc
+++ b/meta-python/recipes-devtools/python3-paramiko/python3-paramiko.inc
@@ -4,7 +4,7 @@ AUTHOR = "paramiko"
 HOMEPAGE = "https://www.paramiko.org/"
 BUGTRACKER = "https://github.com/paramiko/paramiko/issues"
 SECTION = "development"
-LICENSE = "LGPL-2.1"
+LICENSE = "LGPL-2.1-only"
 
 CVE_PRODUCT = ""
 

--- a/meta-python/recipes-devtools/python3-trash-cli/python3-trash-cli.inc
+++ b/meta-python/recipes-devtools/python3-trash-cli/python3-trash-cli.inc
@@ -4,6 +4,6 @@ AUTHOR = "Andrea Francia"
 HOMEPAGE = "https://github.com/andreafrancia/trash-cli"
 BUGTRACKER = "https://github.com/andreafrancia/trash-cli/issues"
 SECTION = "tools"
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 
 CVE_PRODUCT = ""

--- a/recipes-oss/cppcheck/cppcheck.inc
+++ b/recipes-oss/cppcheck/cppcheck.inc
@@ -4,6 +4,6 @@ AUTHOR = "Daniel Marjamäki <daniel.marjamaki@gmail.com>"
 HOMEPAGE = "http://cppcheck.sourceforge.net/"
 BUGTRACKER = "https://trac.cppcheck.net/"
 SECTION = "development"
-LICENSE = "GPL-3.0+"
+LICENSE = "GPL-3.0-or-later"
 
 CVE_PRODUCT = ""

--- a/recipes-oss/nlopt/nlopt.inc
+++ b/recipes-oss/nlopt/nlopt.inc
@@ -4,6 +4,6 @@ AUTHOR = "Steven G. Johnson <stevenj@alum.mit.edu>"
 HOMEPAGE = "https://github.com/stevengj/nlopt"
 BUGTRACKER = "https://github.com/stevengj/nlopt/issues"
 SECTION = "development"
-LICENSE = "LGPLv2+"
+LICENSE = "LGPL-2.0-or-later"
 
 CVE_PRODUCT = ""

--- a/recipes-oss/xclip/xclip.inc
+++ b/recipes-oss/xclip/xclip.inc
@@ -4,6 +4,6 @@ AUTHOR = "Peter Åstrand <astrand@lysator.liu.se>"
 HOMEPAGE = "https://github.com/astrand/xclip"
 BUGTRACKER = "https://github.com/astrand/xclip/issues"
 SECTION = "tools"
-LICENSE = "GPLv2+"
+LICENSE = "GPL-2.0-or-later"
 
 CVE_PRODUCT = ""


### PR DESCRIPTION
Migrates remaining old style license names to their new name. Backports are excluded from this.

closes  #211