### PR TITLE
Address error in packagegroup-protos-oss

### DIFF
--- a/recipes-oss/packagegroups/packagegroup-protos-oss.bb
+++ b/recipes-oss/packagegroups/packagegroup-protos-oss.bb
@@ -1,5 +1,7 @@
 SUMMARY = "PROTOS open source software package group"
 
+PACKAGE_ARCH = "${TUNE_PKGARCH}"
+
 inherit packagegroup
 
 RDEPENDS:${PN} = "\


### PR DESCRIPTION
```
ERROR: packagegroup-protos-oss-1.0-r0 do_package_write_rpm: An allarch packagegroup shouldn't depend on packages which are dynamically renamed (cmocka-dbg to libcmocka-dbg)
```