### PR TITLE
Update Catch v3.5.3

### DIFF
--- a/recipes-test/catch3/catch3_3.5.3.bb
+++ b/recipes-test/catch3/catch3_3.5.3.bb
@@ -3,7 +3,7 @@ require ${PN}.inc
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=e4224ccaecb14d942c71d31bef20d78c"
 
 SRC_URI = "git://github.com/catchorg/Catch2.git;protocol=https;nobranch=1"
-SRCREV = "05e10dfccc28c7f973727c54f850237d07d5e10f"
+SRCREV = "8ac8190e494a381072c89f5e161b92a08d98b37b"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Updates Catch to latest v3.5.3 (#216).