### PR TITLE
Don't silently fall back to x86 if an invalid architecture is set

### DIFF
--- a/meta/classes/build_settings.bbclass
+++ b/meta/classes/build_settings.bbclass
@@ -11,12 +11,16 @@
 # accordingly
 
 def build_settings(d):
-  if (d.getVar("YOCTO_TARGET_ARCH") == "x86_64"):
+  arch = d.getVar("YOCTO_TARGET_ARCH")
+
+  if arch == "x86_64":
     opt_machine = "genericx86-64"
     opt_defaulttune = "core2-64"
-  else:
+  elif arch == "x86":
     opt_machine = "genericx86"
     opt_defaulttune = "i586"
+  else:
+    bb.error("Unsupported target arch: %s" % arch)
 
   d.appendVar("IMAGE_FSTYPES", " tar.gz")
   d.setVar("IMAGE_VERSION_SUFFIX", "-" + d.getVar('DISTRO_VERSION'))


### PR DESCRIPTION
Raises an error on unsupported architectures instead of silently using x86 (which support is dropped; #218).