### PR TITLE
Add COMPATIBLE_MACHINES for debugpy

### DIFF
--- a/recipes-oss/debugpy/debugpy_1.8.0.bb
+++ b/recipes-oss/debugpy/debugpy_1.8.0.bb
@@ -38,3 +38,5 @@ inherit pypi setuptools3
 RDEPENDS:${PN} += "glibc"
 
 BBCLASSEXTEND = "native nativesdk"
+
+COMPATIBLE_MACHINES="^(genericx86|genericx86-64|mc-x86-32|mc-x86-64|wsl-x86-64)$"

--- a/recipes-oss/debugpy/debugpy_1.8.0.bb
+++ b/recipes-oss/debugpy/debugpy_1.8.0.bb
@@ -39,4 +39,4 @@ RDEPENDS:${PN} += "glibc"
 
 BBCLASSEXTEND = "native nativesdk"
 
-COMPATIBLE_MACHINES="^(genericx86|genericx86-64|mc-x86-32|mc-x86-64|wsl-x86-64)$"
+COMPATIBLE_MACHINES="^(genericx86-64|mc-x86-64|wsl-x86-64)$"


### PR DESCRIPTION
    COMPATIBLE_MACHINES for debugpy

    Without this setting, the build meta-protos for other
    architectures throws an error even when debugpy is not build.
    This is caused by the MACHINE_ARCH test during parsing for each architecture.
    Even with the error, the build is successfull for unsupported
    architectures.

    The correct way to handle this would be to ignore/not parse this recipe
    for non supported architectures. With this change, any build depending
    on debugpy would fail, but independend build work as expected.