### PR TITLE
python3-pymodbus 3.6.7 backport

### DIFF
--- a/meta-python/recipes-devtools/python3-pymodbus/backport.md
+++ b/meta-python/recipes-devtools/python3-pymodbus/backport.md
@@ -1,0 +1,6 @@
+# Backport
+
+Available with *meta-oe scarthgap (Yocto Project 5.0)*.
+
+Upstream revision: `cb74f0eab2373f7cb7115385c6481b84c0f91d1c` *(modified)*
+

--- a/meta-python/recipes-devtools/python3-pymodbus/python3-pymodbus_3.6.7.bb
+++ b/meta-python/recipes-devtools/python3-pymodbus/python3-pymodbus_3.6.7.bb
@@ -1,0 +1,31 @@
+SUMMARY = "A fully featured modbus protocol stack in python"
+HOMEPAGE = "https://github.com/riptideio/pymodbus/"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=eba8057aa82c058d2042b4b0a0e9cc63"
+
+SRC_URI[sha256sum] = "e6cefac57f8d0e887ef49a705743787d8f1f005df94bd148e3da43c2599c77f3"
+
+inherit pypi python_flit_core
+
+PACKAGECONFIG ??= ""
+PACKAGECONFIG[repl] = ",,,python3-aiohttp python3-click python3-prompt-toolkit python3-pygments python3-pyserial-asyncio"
+PACKAGECONFIG[asyncio] = ",,,python3-pyserial-asyncio"
+PACKAGECONFIG[tornado] = ",,,python3-tornado"
+PACKAGECONFIG[twisted] = ",,,python3-twisted-conch"
+PACKAGECONFIG[redis] = ",,,python3-redis"
+PACKAGECONFIG[sql] = ",,,python3-sqlalchemy"
+
+RDEPENDS:${PN} += " \
+    python3-asyncio \
+    python3-core \
+    python3-io \
+    python3-json \
+    python3-logging \
+    python3-math \
+    python3-netserver \
+"
+
+RDEPENDS:${PN} += " \
+    python3-pyserial \
+    python3-six \
+"


### PR DESCRIPTION
python3-pymodbus 3.6.7 is available with Scarthgap, but needs `python_flit_core` instead of `python_setuptools_build_meta` for Kirkstone compatibility.