### PR TITLE
Update Cppcheck v2.14.0

### DIFF
--- a/recipes-oss/cppcheck/cppcheck_2.14.0.bb
+++ b/recipes-oss/cppcheck/cppcheck_2.14.0.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
 DEPENDS += "libpcre"
 
 SRC_URI = "git://github.com/danmar/cppcheck.git;protocol=https;nobranch=1"
-SRCREV = "da29903ffcbde465b6c2b47e8dc38277743f47ec"
+SRCREV = "9c4ed8fa58aed48a8a364ee8193ac9ab50a92602"
 
 S = "${WORKDIR}/git"
 
@@ -15,7 +15,6 @@ EXTRA_OECMAKE = "\
     -DBUILD_TESTS=OFF \
     -DDISABLE_DMAKE=ON \
     -DHAVE_RULES=ON \
-    -DUSE_MATCHCOMPILER=ON \
 "
 
 FILES:${PN} += "${datadir}/Cppcheck/"


### PR DESCRIPTION
This version has a different option handling of `USE_MATCHCOMPILER`.