### PR TITLE
Update Catch 3.8.0

### DIFF
--- a/recipes-test/catch3/catch3_3.8.0.bb
+++ b/recipes-test/catch3/catch3_3.8.0.bb
@@ -3,7 +3,7 @@ require ${PN}.inc
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=e4224ccaecb14d942c71d31bef20d78c"
 
 SRC_URI = "git://github.com/catchorg/Catch2.git;protocol=https;nobranch=1"
-SRCREV = "fa43b77429ba76c462b1898d6cd2f2d7a9416b14"
+SRCREV = "914aeecfe23b1e16af6ea675a4fb5dbd5a5b8d0a"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Kirkstone version of https://github.com/jhnc-oss/protos/pull/35.